### PR TITLE
Add usage documentation to agentic module

### DIFF
--- a/src/sage/agentic/__init__.py
+++ b/src/sage/agentic/__init__.py
@@ -1,1 +1,28 @@
-"""SAGE Agentic Loop — autonomous command retry, fix, and verification engine."""
+"""SAGE Agentic Loop — autonomous command retry, fix, and verification engine.
+
+Quick usage:
+
+    from sage.agentic.loop import AgenticLoop
+    from sage.agentic.engine import Autonomy
+
+    loop = AgenticLoop(autonomy=Autonomy.AUTO, max_retries=3)
+    result = loop.run("python -m pytest")
+
+    if result.state.value == "done":
+        print("Command succeeded")
+    else:
+        print(f"Failed after {result.attempts} attempts: {result.message}")
+
+Autonomy levels:
+    - SUGGEST: only report fix suggestions, never auto-run
+    - ASK: suggest fix and wait for confirmation
+    - AUTO: automatically apply non-destructive fixes and retry
+
+Configuration via sage.toml:
+
+    [agentic]
+    autonomy = "suggest"
+    max_retries = 3
+    auto_fix_patterns = ["missing_module", "permission", "port_in_use"]
+    never_auto_fix = ["git_force_push", "rm_rf", "drop_table"]
+"""


### PR DESCRIPTION
## Summary

- Add quick-start code examples to `sage.agentic` package docstring
- Document all three autonomy levels (SUGGEST, ASK, AUTO)
- Add `sage.toml` configuration reference for the agentic loop

This helps developers who install SAGE and want to integrate the agentic loop into their workflows understand how to use it without digging through source code.

## Test plan

- [x] `python -m pytest` passes (no functional change, docs only)
- [x] `python -c "import sage.agentic; help(sage.agentic)"` shows the new docs