### PR TITLE
Publish wrapper metadata to MCP Registry

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,25 @@
+name: Publish MCP metadata
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install official MCP publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate with GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish wrapper metadata
+        run: ./mcp-publisher publish server.json


### PR DESCRIPTION
Adds the official GitHub OIDC MCP Registry publisher workflow for wrapper-only metadata. It does not publish GUI or UI artifacts.